### PR TITLE
Fix VotifierEvent being called async on Bukkit and sync on Folia

### DIFF
--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -395,13 +395,13 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
 
         if (FOLIA_SUPPORTED) {
             getServer().getGlobalRegionScheduler().run(
-                    this, (task) -> getServer().getPluginManager().callEvent(new VotifierEvent(vote, false))
+                    this, (task) -> getServer().getPluginManager().callEvent(new VotifierEvent(vote, true))
             );
             return;
         }
 
         getServer().getScheduler().runTask(
-                this, () -> getServer().getPluginManager().callEvent(new VotifierEvent(vote, true))
+                this, () -> getServer().getPluginManager().callEvent(new VotifierEvent(vote))
         );
     }
 }


### PR DESCRIPTION
This is backwards since Folia has no "main thread" so it needs to be called async and trying to call the event async on Bukkit resulted in a exception. This is also backwards from original NuVotifer [here](https://github.com/NuVotifier/NuVotifier/blob/master/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java#L383-L391) which calls the event correctly (sync on Bukkit, aysnc on Folia)

<details>
  <summary>Exception before this change on Bukkit</summary>

```java
java.lang.IllegalStateException: VotifierEvent may only be triggered asynchronously.
    at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:59) ~[]
    at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[]
    at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:617) ~[]
    at com.vexsoftware.votifier.NuVotifierBukkit.lambda$fireVotifierEvent$2(NuVotifierBukkit.java:404) ~[nuvotifier-bukkit-3.0.0-SNAPSHOT-dist.jar:?]
    at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftTask.run(CraftTask.java:100) ~[]
    at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:482) ~[]
    at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1650) ~[]
    at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:469) ~[]
    at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1533) ~[]
    at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1234) ~[]
    at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[]
    at java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

Exception seems to be a bit contradicting as well but..

</details>