### PR TITLE
fix: dead repo link

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -10,7 +10,7 @@ applyShadowConfiguration()
 repositories {
     maven {
         name = "paper"
-        url = uri("https://papermc.io/repo/repository/maven-public/")
+        url = uri("https://repo.papermc.io/repository/maven-public/")
     }
 }
 


### PR DESCRIPTION
papermc retired this repo, so you have to use their new repository